### PR TITLE
removes file extension as it is already read in

### DIFF
--- a/mlops-001/lesson1/03_Baseline.ipynb
+++ b/mlops-001/lesson1/03_Baseline.ipynb
@@ -160,7 +160,7 @@
    "outputs": [],
    "source": [
     "# assign paths\n",
-    "df[\"image_fname\"] = [processed_dataset_dir/f'images/{f}.jpg' for f in df.File_Name.values]\n",
+    "df[\"image_fname\"] = [processed_dataset_dir/f'images/{f}' for f in df.File_Name.values]\n",
     "df[\"label_fname\"] = [label_func(f) for f in df.image_fname.values]"
    ]
   },


### PR DESCRIPTION
.jpg extension was already read in as file name is being read, so adding .jpg produced an error with the name the model was trying to read was img.jpg.jpg. And this caused error during dataloading.

```python3
df[\"image_fname\"] = [processed_dataset_dir/f'images/{f}.jpg' for f in df.File_Name.values]
```

This code was causing error while trying to create the dataloader for training.

`df.File_Name.values` would already take in full file names including the file extension, **.jpg**, so the code `processed_dataset_dir/f'images/{f}.jpg` would make the string like this: **img_name.jpg.jpg**, and this would cause error.

I changed it to:

```python3
df[\"image_fname\"] = [processed_dataset_dir/f'images/{f}' for f in df.File_Name.values]
```
and this would read the full image file name correctly. And .jpg extension will be read only once. 

While the earlier gave an error while dataloading, and the dataloader won't create, my correction takes away the error, and the dataloader is created correctly, and training runs properly. I checked.