### PR TITLE
adds easier data source downloading options for LLM course

### DIFF
--- a/llm-apps-course/notebooks/01. Using_APIs.ipynb
+++ b/llm-apps-course/notebooks/01. Using_APIs.ipynb
@@ -71,6 +71,7 @@
     "  if any(['VSCODE' in x for x in os.environ.keys()]):\n",
     "    print('Please enter password in the VS Code prompt at the top of your VS Code window!')\n",
     "  os.environ[\"OPENAI_API_KEY\"] = getpass(\"Paste your OpenAI key from: https://platform.openai.com/account/api-keys\\n\")\n",
+    "  openai.api_key = os.getenv(\"OPENAI_API_KEY\", \"\")\n",
     "\n",
     "assert os.getenv(\"OPENAI_API_KEY\", \"\").startswith(\"sk-\"), \"This doesn't look like a valid OpenAI API key\"\n",
     "print(\"OpenAI API key configured\")"

--- a/llm-apps-course/notebooks/02. Generation.ipynb
+++ b/llm-apps-course/notebooks/02. Generation.ipynb
@@ -45,10 +45,14 @@
    "source": [
     "import os\n",
     "import random\n",
-    "from pathlib import Path\n",
+    "\n",
     "import openai\n",
     "import tiktoken\n",
+    "\n",
+    "from pathlib import Path\n",
     "from pprint import pprint\n",
+    "from getpass import getpass\n",
+    "\n",
     "from rich.markdown import Markdown\n",
     "import pandas as pd\n",
     "from tenacity import (\n",
@@ -78,6 +82,7 @@
     "  if any(['VSCODE' in x for x in os.environ.keys()]):\n",
     "    print('Please enter password in the VS Code prompt at the top of your VS Code window!')\n",
     "  os.environ[\"OPENAI_API_KEY\"] = getpass(\"Paste your OpenAI key from: https://platform.openai.com/account/api-keys\\n\")\n",
+    "  openai.api_key = os.getenv(\"OPENAI_API_KEY\", \"\")\n",
     "\n",
     "assert os.getenv(\"OPENAI_API_KEY\", \"\").startswith(\"sk-\"), \"This doesn't look like a valid OpenAI API key\"\n",
     "print(\"OpenAI API key configured\")"
@@ -182,6 +187,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test if examples.txt is present, download if not\n",
+    "if not Path(\"examples.txt\").exists():\n",
+    "    !wget https://raw.githubusercontent.com/wandb/edu/main/llm-apps-course/notebooks/examples.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -252,6 +268,18 @@
    "metadata": {},
    "source": [
     "Let's create a function to find all the markdown files in a directory and return it's content and path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# check if directory exists, if not, create it and download the files, e.g if running in colab\n",
+    "if not os.path.exists(\"../docs_sample/\"):\n",
+    "  !git clone https://github.com/wandb/edu.git\n",
+    "  !cp -r edu/llm-apps-course/docs_sample ../"
    ]
   },
   {
@@ -608,7 +636,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Based on user [feedback](https://discord.com/channels/979771698612154459/983676008072900629/1123982031810994287)

- Set openai key using `openai.api_key = `
- adding missing getpass import
- add download option for examples.txt (if running notebook in colab)
- add download option for "doc_sample" (if running notebook in colab)