### PR TITLE
Add NeurIPS LLM Efficiency Challenge course repo 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "llm-training-course/neurips-llm-efficiency-challenge"]
+	path = llm-training-course/neurips-llm-efficiency-challenge
+	url = https://github.com/ayulockin/neurips-llm-efficiency-challenge


### PR DESCRIPTION
Moved the original repo https://github.com/ayulockin/neurips-llm-efficiency-challenge to `llm-training-course` dir as a submodule so that any change made to the original repo can be fetched easily in this edu repo. Do let me know it if works. :)

cc: @tcapelle 