### PR TITLE
Fixes Typo in Initial Prompt for Chapter 1 of RAG++ course

### DIFF
--- a/rag-advanced/notebooks/prompts/initial_system.txt
+++ b/rag-advanced/notebooks/prompts/initial_system.txt
@@ -1,1 +1,1 @@
-Answer to the following question about W&B. Provide an helful and complete answer based only on the provided documents.
+Answer to the following question about W&B. Provide an helpful and complete answer based only on the provided documents.


### PR DESCRIPTION
This pull request resolves a typo in the initial prompt for Chapter 1 of RAG++: From POC to Production.

Have attached screenshot for your reference

![2024-11-27 at 07 38 49@2x](https://github.com/user-attachments/assets/e232f968-5835-46ab-bf35-80a3278da01c)

